### PR TITLE
Change pdf reader to default pdf reader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS), Darwin)
 	PDF_READER = open
 endif
 ifeq ($(OS), Linux)
-	PDF_READER = evince
+	PDF_READER = xdg-open
 endif
 
 all: pdf


### PR DESCRIPTION
`xdg-open` will check what software is setup to open pdfs on the machine on the user.